### PR TITLE
Fixes to enable building tap plugins on msvc

### DIFF
--- a/ladspa.h
+++ b/ladspa.h
@@ -586,6 +586,10 @@ typedef struct _LADSPA_Descriptor {
    returning NULL, so the plugin count can be determined by checking
    for the least index that results in NULL being returned. */
 
+#ifdef _MSC_VER
+// needed to get it to compile on msvc
+__declspec(dllexport)
+#endif
 const LADSPA_Descriptor * ladspa_descriptor(unsigned long Index);
 
 /* Datatype corresponding to the ladspa_descriptor() function. */

--- a/tap_reverb.h
+++ b/tap_reverb.h
@@ -19,6 +19,9 @@
 #define _ISOC99_SOURCE
 #endif
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #include <stdint.h>
 

--- a/tap_utils.h
+++ b/tap_utils.h
@@ -20,6 +20,11 @@
 #endif
 
 #include <stdint.h>
+
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+
 #include <math.h>
 
 /* push a sample into a ringbuffer and return the sample falling out */


### PR DESCRIPTION
I am working on enabling MSVC support for ladspa plugins on lmms. These changes are needed to enable tap plugins there and I'm upstreaming that support through this pr.